### PR TITLE
Changed the INSTALL_PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MKFILE_DIR := $(dir $(MKFILE_PATH))
 ABS_MKFILE_PATH := $(abspath $(MKFILE_PATH))
 ABS_MKFILE_DIR := $(abspath $(MKFILE_DIR))
 ABS_BUILDDIR=$(ABS_MKFILE_DIR)/$(BUILDDIR)
-INSTALL_PATH=~/.local/share/gnome-shell/extensions
+INSTALL_PATH=~/.local/share/gnome-shell/extensions/azan@faissal.bensefia.id
 #=============================================================================
 default_target: all
 .PHONY: clean all zip install


### PR DESCRIPTION
As salamu alaykum wa rahmatullahi wa barakatuhu my dear brother,

Jazak Allahu khayran for your effort in reviving this excellent Gnome Shell extension. 

I have tried to install it with "make install" - but it didn't work out as the folder needs to be created according to the UUID. 

So I had to change the INSTALL_PATH accordingly to:

INSTALL_PATH=~/.local/share/gnome-shell/extensions/azan@faissal.bensefia.id
