### PR TITLE
Revert "Changed the INSTALL_PATH"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MKFILE_DIR := $(dir $(MKFILE_PATH))
 ABS_MKFILE_PATH := $(abspath $(MKFILE_PATH))
 ABS_MKFILE_DIR := $(abspath $(MKFILE_DIR))
 ABS_BUILDDIR=$(ABS_MKFILE_DIR)/$(BUILDDIR)
-INSTALL_PATH=~/.local/share/gnome-shell/extensions/azan@faissal.bensefia.id
+INSTALL_PATH=~/.local/share/gnome-shell/extensions
 #=============================================================================
 default_target: all
 .PHONY: clean all zip install


### PR DESCRIPTION
Reverts raihan2000/azan-gnome-shell-extension#1

[ λ azan-gnome-shell-extension ] make install
rm -rf build
mkdir -p build/azan@faissal.bensefia.id
cp -r src/* build/azan@faissal.bensefia.id
mkdir -p ~/.local/share/gnome-shell/extensions/azan@faissal.bensefia.id/azan@faissal.bensefia.id
cp -R -p build/azan@faissal.bensefia.id/* ~/.local/share/gnome-shell/extensions/azan@faissal.bensefia.id/azan@faissal.bensefia.id

sorry this needs to revert cuz its creating another folder inside