### PR TITLE
Remove "Imsak" as it has no islamic basis

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -54,7 +54,6 @@ class Azan extends PanelMenu.Button {
                                  "Ramadhan", "Shawwal", "Dhul Qa'ada", "Dhul Hijja");
 
     this._timeNames = {
-        imsak: 'Imsak',
         fajr: 'Fajr',
         sunrise: 'Sunrise',
         dhuhr: 'Dhuhr',
@@ -66,7 +65,6 @@ class Azan extends PanelMenu.Button {
     };
 
     this._timeConciseLevels = {
-      imsak: 0,
       fajr: 1,
       sunrise: 0,
       dhuhr: 1,


### PR DESCRIPTION
As salamu alaykum wa rahmatullahi wa barakatuhu,

Jazak Allahu khayran for this Gnome Shell Extension.

I am using it daily to remind me of the prayer times.

May Allah swt bless you for sharing your work so that other brothers and sisters benefit from it.

Today I have found something in it which is wrong with regards to the islamic teachings we have been given from Muhammad saws.

"Imsak" is according to the Ulama a form of Bid'a (rennovation), which was taken into the religion afterwards.

https://islamqa.info/en/answers/12602/meaning-of-imsak-and-its-time

We Muslims should abstain from anything that is Bid'a.

Wa Allahu alam.
